### PR TITLE
Removes deprecation warning from Product class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/projectjellyfish/jellyfish-demo.git
-  revision: ee54d58299d0ed71963ec788259e6bb9a3409c63
+  revision: f6b632efafdd897bec0037026683ae93858b6910
   specs:
     jellyfish-demo (0.0.1)
       faker

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -41,11 +41,13 @@ class Product < ActiveRecord::Base
 
   scope :active, -> { where(active: true) }
 
-  # TODO: Move contents of ProductType.order_questions here after removal of deprecated method
-  delegate :order_questions, to: :product_type
+  def order_questions
+    []
+  end
 
-  # TODO: Move contents of ProductType.service_class here after removal of deprecated method
-  delegate :service_class, to: :product_type
+  def service_class
+    'Service'.constantize
+  end
 
   def self.policy_class
     ProductPolicy

--- a/app/models/product_type.rb
+++ b/app/models/product_type.rb
@@ -55,18 +55,8 @@ class ProductType < ActiveRecord::Base
     []
   end
 
-  def order_questions
-    ActiveSupport::Deprecation.warn 'ProductType.order_questions will be removed in a future update, use Product.order_questions instead', caller
-    []
-  end
-
   def product_class
     'Product'.constantize
-  end
-
-  def service_class
-    ActiveSupport::Deprecation.warn 'ProductType.service_class will be removed in a future update, use Product.service_class instead', caller
-    'Service'.constantize
   end
 
   def self.create_existing(product_type, opts)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Removes deprecation warning from Product class in build logs.

### Related Issue
https://github.com/boozallen/projectjellyfish/issues/1133

### Motivation and Context
To support more complex extension development, the `order_questions` and `service_class` methods were set to be moved from the `ProductType` class to the `Product` class. This change allows custom products to be defined in an extension and be linked to their corresponding `ProductType` in the marketplace. 

The JellyfishAzure extension already has `ProductType` and `Product` setup with the correct methods, however the JellyfishDemo and JellyfishAWS extensions needed to be updated to align against this change. 
- See [here](https://github.com/projectjellyfish/jellyfish-demo/pull/13) for PR that updated JellyfishDemo
- See [here](https://github.com/projectjellyfish/jellyfish-aws/pull/2/files) for PR that updated JellyfishAWS
  
### How Has This Been Tested?
- Ran Rubocop and verified no offenses
- Ran RSpec and verified that all tests still pass and that deprecation warnings no longer appear in the build log.
- Added Server, SQL, and Widget products from the JellyfishDemo extension on a local deployment of JF and verified that cart checkout with provisioning works as expected.
- Added EC2, RDS, and S3 products from the JellyfishAWS extension on a local deployment of JF with valid AWS credentials and verified that cart checkout with provisioning works as expected.

### Screenshots (if appropriate):
n/a

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Adds database migrations (Requires all environments to run `rake db:migrate` to work)
- [x] Adds new Gemfile dependencies (Requires all environments to run `bundle install` to work)
- [ ] Adds new ENV variables (description of ENV and purpose is required in the above description)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My code has been cleaned of commented, logging, and inline test code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Moves the `order_questions` and `service_class` methods from ProductType
into Product for the generic class definitions.

JellyfishDemo and JellyfishAWS have been updated to accommodate those
changes.

JellyfishAzure already was using the new architecture, so no
change was required there.

Closes https://github.com/boozallen/projectjellyfish/issues/1133.