### PR TITLE
Update redis-store to latest version to fix vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,7 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     libv8 (5.3.332.38.3)
+    libv8 (5.3.332.38.3-x86_64-darwin-16)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -231,9 +232,9 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    redis (3.3.2)
-    redis-store (1.3.0)
-      redis (>= 2.2)
+    redis (3.3.5)
+    redis-store (1.4.1)
+      redis (>= 2.2, < 5)
     ruby-progressbar (1.8.1)
     rufus-scheduler (3.3.4)
       tzinfo
@@ -305,6 +306,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-16
 
 DEPENDENCIES
   acts-as-taggable-on (~> 4.0.0)
@@ -367,4 +369,4 @@ DEPENDENCIES
   with_advisory_lock (~> 3.1.0)
 
 BUNDLED WITH
-   1.14.5
+   1.15.3


### PR DESCRIPTION
### Description
Update the redis-store gem per vulnerability warning in redis-store < 1.4.0

### How Has This Been Tested?
Web application and sidekiq still work, no new failures in rubocop.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Adds database migrations (Requires all environments to run `rake db:migrate` to work)
- [x] Adds new Gemfile dependencies (Requires all environments to run `bundle install` to work)
- [ ] Adds new ENV variables (description of ENV and purpose is required in the above description)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My code has been cleaned of commented, logging, and inline test code.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
